### PR TITLE
Device information

### DIFF
--- a/custom_components/cleanprofs/binary_sensor.py
+++ b/custom_components/cleanprofs/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, FIXED_PRODUCTS
+from .entity import CleanProfsBaseEntity
 from .util import isoToday, nextDate
 
 # Create binary sensor entities for the config entry.
@@ -15,21 +16,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,async_add_en
     coordinator = hass.data[DOMAIN]["coordinator"]
 
     desc = BinarySensorEntityDescription(
-        key="cleanprofs_cleaning",
+        key="cleaning",
         name= "Cleanprofs Cleaning",
         icon="mdi:trash-can"
     )
 
-    async_add_entities([CleanProfsCleaningBinarySensor(coordinator, desc)])
+    async_add_entities([CleanProfsCleaningBinarySensor(coordinator, entry, desc)])
                        
-class CleanProfsCleaningBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class CleanProfsCleaningBinarySensor(CleanProfsBaseEntity, BinarySensorEntity):
     # Binary sensor that turns on when *any* product has to be cleaned
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, description: BinarySensorEntityDescription) -> None:
-        super().__init__(coordinator)
+    def __init__(self, coordinator, entry: ConfigEntry, description: BinarySensorEntityDescription) -> None:
+        super().__init__(coordinator, entry)
         self.entity_description = description
-        self._attr_unique_id = "cleanprofs_cleaning"
+        self._attr_unique_id = f"{entry.entry_id}_cleaning"
 
 
     @property
@@ -46,7 +47,7 @@ class CleanProfsCleaningBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def extra_state_attributes(self):
         items = self.coordinator.data or []
-        today = isoToday
+        today = isoToday()
 
         cleaningProducts: list[str] = []
         nextDates: dict[str, str | None] = {}
@@ -59,14 +60,6 @@ class CleanProfsCleaningBinarySensor(CoordinatorEntity, BinarySensorEntity):
         
         return {
             "cleaningProductToday": cleaningProducts,
-            "NextDates": nextDates
+            "nextdates": nextDates
         }
     
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, "cleanprofs_device")},
-            name="CleanProfs",
-            manufacturer="CleanProfs",
-            model="Planning API",
-        )

--- a/custom_components/cleanprofs/entity.py
+++ b/custom_components/cleanprofs/entity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+def _read_manifest_version() -> str | None:
+    try:
+        manifest_path = Path(__file__).parent / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        return manifest.get("version")
+    except Exception:
+        return None
+
+
+_MANIFEST_VERSION = _read_manifest_version()
+
+
+class CleanProfsBaseEntity(CoordinatorEntity):
+    """Base Entity for all CleanProfs entities"""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, entry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="CleanProfs",
+            manufacturer="Hessels Automation",
+            model="Cleaning schedule API",
+            sw_version=_MANIFEST_VERSION,
+        )

--- a/custom_components/cleanprofs/entity.py
+++ b/custom_components/cleanprofs/entity.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # Enable postponed evaluation of type hints (Py<3.11 compatibility)
 
 import json
 from pathlib import Path
@@ -10,32 +10,61 @@ from .const import DOMAIN
 
 
 def _read_manifest_version() -> str | None:
+    """Read the integration version from manifest.json.
+
+    Returns:
+        The version string from manifest.json (key: "version"), or None if:
+        - the file cannot be read,
+        - the JSON is invalid,
+        - the key is missing.
+    """
     try:
+        # manifest.json is located in the same folder as this file (custom_components/cleanprofs/)
         manifest_path = Path(__file__).parent / "manifest.json"
+
+        # Load and parse the manifest so we can use its version as the device software version
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
         return manifest.get("version")
     except Exception:
+        # Never break entity setup because of a version-read problem
         return None
 
 
+# Cache the manifest version once at import time (cheap + avoids rereading file per entity)
 _MANIFEST_VERSION = _read_manifest_version()
 
 
 class CleanProfsBaseEntity(CoordinatorEntity):
-    """Base Entity for all CleanProfs entities"""
+    """Base Entity for all CleanProfs entities.
 
+    All entities that inherit from this class will automatically:
+    - be linked to the same Home Assistant "Device" (via identifiers),
+    - show consistent device metadata (manufacturer/model/software version).
+    """
+
+    # Let HA treat the entity name as a sub-name under the device name
+    # (often results in nicer naming in the UI)
     _attr_has_entity_name = True
 
     def __init__(self, coordinator, entry) -> None:
+        """Initialize the base entity with a coordinator and config entry."""
         super().__init__(coordinator)
-        self._entry = entry
+        self._entry = entry  # Keep reference to the config entry for stable device identifiers
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return Home Assistant DeviceInfo for grouping entities under one device.
+
+        Home Assistant will group all entities that return the same identifiers
+        into a single Device.
+        """
         return DeviceInfo(
+            # Unique and stable per config entry: gives 1 device per configured account/instance
             identifiers={(DOMAIN, self._entry.entry_id)},
             name="CleanProfs",
             manufacturer="Hessels Automation",
             model="Cleaning schedule API",
+            # Show the integration version (from manifest.json) as "Software version" on the device page
             sw_version=_MANIFEST_VERSION,
         )

--- a/custom_components/cleanprofs/manifest.json
+++ b/custom_components/cleanprofs/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "cleanprofs",
   "name": "CleanProfs",
-  "version": "2026.4.29",
-  "documentation": "https://example.invalid",
+  "version": "2026.4.30",
+  "documentation": "https://github.com/jrhessels/cleanprofs-ha",
   "requirements": [],
   "codeowners": ["@jrhessels"],
   "config_flow": true,
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/jrhessels/cleanprofs-ha/issues"
 }

--- a/custom_components/cleanprofs/manifest.json
+++ b/custom_components/cleanprofs/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cleanprofs",
   "name": "CleanProfs",
-  "version": "2026.4.30",
+  "version": "2026.4.29",
   "documentation": "https://github.com/jrhessels/cleanprofs-ha",
   "requirements": [],
   "codeowners": ["@jrhessels"],

--- a/custom_components/cleanprofs/sensor.py
+++ b/custom_components/cleanprofs/sensor.py
@@ -1,50 +1,48 @@
+# sensor.py
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, FIXED_PRODUCTS
+from .entity import CleanProfsBaseEntity
 from .util import nextDate
 
-# Create sensor entities from the config entry
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     coordinator = hass.data[DOMAIN]["coordinator"]
 
     entities = []
     for productName in FIXED_PRODUCTS:
         desc = SensorEntityDescription(
-            key=f"cleanprofs_{productName}",
-            name=f"Cleanprofs {productName}",
-            icon="mdi:calendar-arrow-right"
+            key=f"cleaning_date_{productName}".lower(),
+            name=f"{productName} cleaning date",
+            icon="mdi:calendar-arrow-right",
         )
-        entities.append(CleanProfsNextDateSensor(coordinator, desc, productName))
+        entities.append(CleanProfsNextDateSensor(coordinator, entry, desc, productName))
+
     async_add_entities(entities)
 
-class CleanProfsNextDateSensor(CoordinatorEntity, SensorEntity):
-    # Sensor that exposes the next pickup date (YYYY-MM-DD) for a single product
-    _attr_has_entity_name = True
 
-    # Initialize the sensor with a coordinator and fixed product name.
-    def __init__(self, coordinator, description: SensorEntityDescription, productName: str) -> None:
-        super().__init__(coordinator)
+class CleanProfsNextDateSensor(CleanProfsBaseEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator,
+        entry: ConfigEntry,
+        description: SensorEntityDescription,
+        productName: str,
+    ) -> None:
+        super().__init__(coordinator, entry)
         self.entity_description = description
         self.productName = productName
-        self._attr_unique_id = f"cleanprofs_{productName}".lower()
-    
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, "cleanprofs_device")},
-            name="CleanProfs",
-            manufacturer="CleanProfs",
-            model="Planning API",
-        )
+        self._attr_unique_id = f"{entry.entry_id}_cleaning_date_{productName}".lower()
 
-    # Return the sensor value (next pickup date or None/unknown)
     @property
     def native_value(self):
         return nextDate(self.coordinator.data or [], self.productName)


### PR DESCRIPTION
Centralized device metadata for CleanProfs by introducing a shared CleanProfsBaseEntity. All entities now inherit from this base to be grouped under a single Home Assistant device per config entry (via stable DeviceInfo.identifiers). The device’s software version is populated from manifest.json (version field) and exposed as sw_version in DeviceInfo, so it shows up on the device page.